### PR TITLE
Fix extract_domain handling of schemeless URLs

### DIFF
--- a/src/utils/text_utils.py
+++ b/src/utils/text_utils.py
@@ -26,12 +26,32 @@ def extract_domain(url):
         抽出されたドメイン
     '''
     try:
+        if not url:
+            return ""
+
         parsed = urlparse(url)
         domain = parsed.netloc
+
+        # スキームが省略されたURL（"example.com/path"など）に対応
+        if not domain:
+            parsed = urlparse(f"//{url}")
+            domain = parsed.netloc or parsed.path
+
+        # パス要素が混ざっている場合はドメイン部分のみ取得
+        domain = domain.split('/')[0]
+
+        # ポート番号が付与されている場合は除去
+        if ':' in domain:
+            domain = domain.split(':', 1)[0]
+
+        # 大文字小文字のゆらぎをなくす
+        domain = domain.lower()
+
         if domain.startswith('www.'):
             domain = domain[4:]
+
         return domain
-    except:
+    except Exception:
         return ""
 
 def is_negative(title, snippet):

--- a/tests/test_text_utils.py
+++ b/tests/test_text_utils.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python
+# coding: utf-8
+
+"""text_utilsモジュールのテスト"""
+
+from pathlib import Path
+import sys
+
+import pytest
+
+# プロジェクトルートをパスに追加
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from src.utils.text_utils import extract_domain
+
+
+@pytest.mark.parametrize(
+    "url, expected",
+    [
+        ("https://www.example.com/path", "example.com"),
+        ("HTTP://Sub.Example.COM/page", "sub.example.com"),
+        ("example.com/about", "example.com"),
+        ("www.example.com", "example.com"),
+        ("example.com:8080/path", "example.com"),
+        ("", ""),
+    ],
+)
+def test_extract_domain(url, expected):
+    """extract_domainがスキーム省略やポート番号などに対応できること"""
+
+    assert extract_domain(url) == expected


### PR DESCRIPTION
## Summary
- normalize URL parsing in `extract_domain` so schemeless inputs, ports, and casing are handled correctly
- add regression tests covering new edge cases for domain extraction

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68da6458341483239987f6f74ee338a2